### PR TITLE
full_tp descriptor

### DIFF
--- a/cuequivariance/cuequivariance/descriptors/__init__.py
+++ b/cuequivariance/cuequivariance/descriptors/__init__.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 from .transposition import transpose
 from .irreps_tp import (
+    full_tensor_product,
     fully_connected_tensor_product,
     channelwise_tensor_product,
     elementwise_tensor_product,
@@ -35,6 +36,7 @@ from .gatr import gatr_linear, gatr_geometric_product, gatr_outer_product
 
 __all__ = [
     "transpose",
+    "full_tensor_product",
     "fully_connected_tensor_product",
     "channelwise_tensor_product",
     "elementwise_tensor_product",

--- a/cuequivariance/cuequivariance/descriptors/irreps_tp.py
+++ b/cuequivariance/cuequivariance/descriptors/irreps_tp.py
@@ -20,29 +20,6 @@ from cuequivariance import segmented_tensor_product as stp
 from cuequivariance.irreps_array.irrep_utils import into_list_of_irrep
 
 
-def get_cuequivariance_descriptor(irreps_in1, irreps_in2):
-    d = stp.SegmentedTensorProduct.from_subscripts("ui,vj,kuv+ijk")
-    irreps_in1 = cue.Irreps("O3", irreps_in1.__str__())
-    irreps_in2 = cue.Irreps("O3", irreps_in2.__str__())
-    G = irreps_in1.irrep_class
-
-    for mul, ir in irreps_in1:
-        d.add_segment(0, (mul, ir.dim))
-    for mul, ir in irreps_in2:
-        d.add_segment(1, (mul, ir.dim))
-
-    for (i1, (mul1, ir1)), (i2, (mul2, ir2)) in itertools.product(
-        enumerate(irreps_in1), enumerate(irreps_in2)
-    ):
-        for ir3 in ir1 * ir2:
-            # for loop over the different solutions of the Clebsch-Gordan decomposition
-            for cg in cue.clebsch_gordan(ir1, ir2, ir3):
-                d.add_path(i1, i2, None, c=cg)
-
-    d = d.normalize_paths_for_operand(-1)
-    return d
-
-
 def fully_connected_tensor_product(
     irreps1: cue.Irreps, irreps2: cue.Irreps, irreps3: cue.Irreps
 ) -> cue.EquivariantTensorProduct:

--- a/cuequivariance/tests/equivariant_tensor_products_test.py
+++ b/cuequivariance/tests/equivariant_tensor_products_test.py
@@ -31,6 +31,12 @@ def test_commutativity_squeeze_flatten():
         == d.flatten_coefficient_modes().squeeze_modes()
     )
 
+    d = descriptors.full_tensor_product(irreps1, irreps2, irreps3).d
+    assert (
+        d.squeeze_modes().flatten_coefficient_modes()
+        == d.flatten_coefficient_modes().squeeze_modes()
+    )
+
     d = descriptors.channelwise_tensor_product(irreps1, irreps2, irreps3).d
     assert (
         d.squeeze_modes().flatten_coefficient_modes()


### PR DESCRIPTION
Congrats on the release ! Wanted to run by the idea of having a weightless `full_tensor_product` descriptor similar to `e3nn_jax.tensor_product`. Feel free to let me know if I might have missed something. Happy to make the PR more production-grade if the idea make sense.