### PR TITLE
Uniformize the python version requirements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4
@@ -61,7 +61,7 @@ jobs:
       matrix:
         include:
           - runner: "ubuntu-latest"
-            python-version: "3.9"
+            python-version: "3.10"
           - runner: "ubuntu-latest"
             python-version: "3.12"
           - runner: "self-hosted"

--- a/cuequivariance/pyproject.toml
+++ b/cuequivariance/pyproject.toml
@@ -24,7 +24,7 @@ description = "CUDA accelerated equivariant operations"
 readme = "../README.md"
 license = { file = "../LICENSES/LICENSE" }
 authors = [{ name = "NVIDIA Corporation" }]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "numpy",
     "scipy",
@@ -35,11 +35,9 @@ dependencies = [
 classifiers = [
     "Intended Audience :: Developers",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
 ]
 
 [tool.hatch.version]

--- a/cuequivariance_jax/pyproject.toml
+++ b/cuequivariance_jax/pyproject.toml
@@ -35,7 +35,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
 ]
 
 [tool.hatch.version]

--- a/cuequivariance_torch/pyproject.toml
+++ b/cuequivariance_torch/pyproject.toml
@@ -24,14 +24,13 @@ description = "CUDA accelerated equivariant operations"
 readme = "../README.md"
 license = { file = "../LICENSES/LICENSE" }
 authors = [{ name = "NVIDIA Corporation" }]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "cuequivariance",
 ]
 classifiers = [
     "Intended Audience :: Developers",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
The backend requires python 3.10. 
- https://pypi.org/project/cuequivariance-ops-torch-cu11
- https://pypi.org/project/cuequivariance-ops-torch-cu12

This PR changes the requirements to have a uniform requirement of python version among the different packages.