### PR TITLE
fix sh l=0

### DIFF
--- a/cuequivariance_torch/cuequivariance_torch/primitives/equivariant_tensor_product.py
+++ b/cuequivariance_torch/cuequivariance_torch/primitives/equivariant_tensor_product.py
@@ -195,7 +195,13 @@ class EquivariantTensorProduct(torch.nn.Module):
             use_fallback=use_fallback,
         )
 
-        if any(d.num_operands != e.num_inputs + 1 for d in e.ds):
+        if (
+            len(e.ds) > 1
+            or any(d.num_operands != e.num_inputs + 1 for d in e.ds)
+            or any(
+                d.num_operands == 2 for d in e.ds
+            )  # special case for Spherical Harmonics ls = [1]
+        ):
             if e.num_inputs == 1:
                 self.tp = SymmetricTPDispatcher(
                     cuet.SymmetricTensorProduct(

--- a/cuequivariance_torch/tests/operations/rotation_test.py
+++ b/cuequivariance_torch/tests/operations/rotation_test.py
@@ -50,6 +50,9 @@ def test_vector_to_euler_angles():
 
 @pytest.mark.parametrize("use_fallback", [False, True])
 def test_inversion(use_fallback: bool):
+    if use_fallback is False and not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
     irreps = cue.Irreps("O3", "2x1e + 1o")
     torch.testing.assert_close(
         cuet.Inversion(

--- a/cuequivariance_torch/tests/operations/rotation_test.py
+++ b/cuequivariance_torch/tests/operations/rotation_test.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pytest
 import torch
 
 import cuequivariance as cue
@@ -47,11 +48,12 @@ def test_vector_to_euler_angles():
     assert torch.allclose(A, B)
 
 
-def test_inversion():
+@pytest.mark.parametrize("use_fallback", [False, True])
+def test_inversion(use_fallback: bool):
     irreps = cue.Irreps("O3", "2x1e + 1o")
     torch.testing.assert_close(
-        cuet.Inversion(irreps, layout=cue.ir_mul)(
-            torch.tensor([1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
-        ),
-        torch.tensor([1.0, 1.0, 1.0, 1.0, 1.0, 1.0, -1.0, -1.0, -1.0]),
+        cuet.Inversion(
+            irreps, layout=cue.ir_mul, device=device, use_fallback=use_fallback
+        )(torch.tensor([[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]], device=device)),
+        torch.tensor([[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, -1.0, -1.0, -1.0]], device=device),
     )

--- a/cuequivariance_torch/tests/operations/spherical_harmonics_test.py
+++ b/cuequivariance_torch/tests/operations/spherical_harmonics_test.py
@@ -26,14 +26,15 @@ device = torch.device("cuda:0") if torch.cuda.is_available() else torch.device("
     "dtype, tol",
     [(torch.float64, 1e-6), (torch.float32, 1e-4)],
 )
-@pytest.mark.parametrize("ell", [1, 2, 3])
-def test_spherical_harmonics(ell: int, dtype, tol):
+@pytest.mark.parametrize("ell", [0, 1, 2, 3])
+@pytest.mark.parametrize("use_fallback", [False, True])
+def test_spherical_harmonics_equivariance(use_fallback: bool, ell: int, dtype, tol):
     vec = torch.randn(3, dtype=dtype, device=device)
     axis = np.random.randn(3)
     angle = np.random.rand()
     scale = 1.3
 
-    yl = cuet.spherical_harmonics([ell], vec, False)
+    yl = cuet.spherical_harmonics([ell], vec, False, use_fallback=use_fallback)
 
     R = torch.from_numpy(cue.SO3(1).rotation(axis, angle)).to(dtype).to(device)
     Rl = torch.from_numpy(cue.SO3(ell).rotation(axis, angle)).to(dtype).to(device)
@@ -44,9 +45,16 @@ def test_spherical_harmonics(ell: int, dtype, tol):
     torch.testing.assert_close(yl1, yl2, rtol=tol, atol=tol)
 
 
-def test_spherical_harmonics_full():
-    vec = torch.randn(3, device=device)
-    ls = [0, 1, 2, 3]
-    yl = cuet.spherical_harmonics(ls, vec, False)
+data_types = [torch.float32, torch.float64]
 
-    assert abs(yl[0] - 1.0) < 1e-6
+if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 8:
+    data_types += [torch.float16, torch.bfloat16]
+
+
+@pytest.mark.parametrize("dtype", data_types)
+@pytest.mark.parametrize("ls", [[0], [1], [2], [0, 1], [0, 1, 2]])
+@pytest.mark.parametrize("use_fallback", [False, True])
+def test_spherical_harmonics_full(dtype, ls: list[int], use_fallback: bool):
+    vec = torch.randn(3, device=device, dtype=dtype)
+    yl = cuet.spherical_harmonics(ls, vec, False, use_fallback=use_fallback)
+    assert yl.shape[-1] == sum(2 * ell + 1 for ell in ls)

--- a/cuequivariance_torch/tests/operations/spherical_harmonics_test.py
+++ b/cuequivariance_torch/tests/operations/spherical_harmonics_test.py
@@ -29,6 +29,9 @@ device = torch.device("cuda:0") if torch.cuda.is_available() else torch.device("
 @pytest.mark.parametrize("ell", [0, 1, 2, 3])
 @pytest.mark.parametrize("use_fallback", [False, True])
 def test_spherical_harmonics_equivariance(use_fallback: bool, ell: int, dtype, tol):
+    if use_fallback is False and not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
     vec = torch.randn(3, dtype=dtype, device=device)
     axis = np.random.randn(3)
     angle = np.random.rand()
@@ -55,6 +58,9 @@ if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 8:
 @pytest.mark.parametrize("ls", [[0], [1], [2], [0, 1], [0, 1, 2]])
 @pytest.mark.parametrize("use_fallback", [False, True])
 def test_spherical_harmonics_full(dtype, ls: list[int], use_fallback: bool):
+    if use_fallback is False and not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
     vec = torch.randn(3, device=device, dtype=dtype)
     yl = cuet.spherical_harmonics(ls, vec, False, use_fallback=use_fallback)
     assert yl.shape[-1] == sum(2 * ell + 1 for ell in ls)


### PR DESCRIPTION
Since now `cuequivariance_ops_torch.SymmetricTensorContraction` supports STP of degree 0 we can simplify the code by removing the special case for degree 0 in `cuet.SymmetricTensorProduct`

```python
import cuequivariance_ops_torch as ops
import torch

f = ops.SymmetricTensorContraction(
    [
        [0, 0],  # degree 0 (was not supported before)
        [0, 0, 1],  # degree 1
        [0, 0, 0, 2],  # degree 2
    ],
    [
        5.0,
        1.0,
        1.0,
    ],
    num_in_segments=1,
    num_couplings=1,
    num_out_segments=3,
    correlation=2,
    math_dtype=torch.float32,
).to(device="cuda")
f(
    torch.tensor([[[2.0]]], device="cuda"),  # input
    torch.tensor([[[2.0]]], device="cuda"),  # coupling
    torch.tensor([0], device="cuda", dtype=torch.int32),
)
```