### PR TITLE
Removing tensor lists from all APIs

### DIFF
--- a/cuequivariance_torch/cuequivariance_torch/__init__.py
+++ b/cuequivariance_torch/cuequivariance_torch/__init__.py
@@ -18,7 +18,7 @@ __version__ = (
     importlib.resources.files(__package__).joinpath("VERSION").read_text().strip()
 )
 
-from .primitives.tensor_product import TensorProduct
+from .primitives.tensor_product import TensorProduct, _Wrapper
 from .primitives.symmetric_tensor_product import (
     SymmetricTensorProduct,
     IWeightedSymmetricTensorProduct,
@@ -57,4 +57,5 @@ __all__ = [
     "vector_to_euler_angles",
     "SphericalHarmonics",
     "layers",
+    "_Wrapper",
 ]

--- a/cuequivariance_torch/cuequivariance_torch/operations/linear.py
+++ b/cuequivariance_torch/cuequivariance_torch/operations/linear.py
@@ -122,4 +122,4 @@ class Linear(torch.nn.Module):
         if weight is None:
             raise ValueError("Weights should not be None")
 
-        return self.f([weight, x])
+        return self.f(weight, x)

--- a/cuequivariance_torch/cuequivariance_torch/operations/rotation.py
+++ b/cuequivariance_torch/cuequivariance_torch/operations/rotation.py
@@ -90,9 +90,7 @@ class Rotation(torch.nn.Module):
         encodings_beta = encode_rotation_angle(beta, self.lmax)
         encodings_alpha = encode_rotation_angle(alpha, self.lmax)
 
-        return self.f(
-            [encodings_gamma, encodings_beta, encodings_alpha, x],
-        )
+        return self.f(encodings_gamma, encodings_beta, encodings_alpha, x)
 
 
 def encode_rotation_angle(angle: torch.Tensor, ell: int) -> torch.Tensor:
@@ -190,4 +188,4 @@ class Inversion(torch.nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Apply the inversion layer."""
-        return self.f([x])
+        return self.f(x)

--- a/cuequivariance_torch/cuequivariance_torch/operations/spherical_harmonics.py
+++ b/cuequivariance_torch/cuequivariance_torch/operations/spherical_harmonics.py
@@ -63,9 +63,11 @@ class SphericalHarmonics(nn.Module):
             torch.Tensor: The spherical harmonics of the input vectors of shape (batch, dim),
             where dim is the sum of 2*l+1 for l in ls.
         """
-        torch._assert(vectors.ndim == 2, "Input must have shape (batch, 3)")
+        torch._assert(
+            vectors.ndim == 2, f"Input must have shape (batch, 3) - got {vectors.shape}"
+        )
 
         if self.normalize:
             vectors = torch.nn.functional.normalize(vectors, dim=1)
 
-        return self.f([vectors])
+        return self.f(vectors)

--- a/cuequivariance_torch/cuequivariance_torch/operations/symmetric_contraction.py
+++ b/cuequivariance_torch/cuequivariance_torch/operations/symmetric_contraction.py
@@ -184,4 +184,4 @@ class SymmetricContraction(torch.nn.Module):
             weight = self.weight
         weight = weight.flatten(1)
 
-        return self.f([weight, x], indices=indices)
+        return self.f(weight, x, indices=indices)

--- a/cuequivariance_torch/cuequivariance_torch/operations/tp_channel_wise.py
+++ b/cuequivariance_torch/cuequivariance_torch/operations/tp_channel_wise.py
@@ -101,6 +101,7 @@ class ChannelWiseTensorProduct(torch.nn.Module):
             use_fallback=use_fallback,
         )
 
+    @torch.jit.ignore
     def extra_repr(self) -> str:
         return (
             f"shared_weights={self.shared_weights}"
@@ -137,11 +138,12 @@ class ChannelWiseTensorProduct(torch.nn.Module):
         if self.weight is not None:
             if weight is not None:
                 raise ValueError("Internal weights are used, weight should be None")
-            return self.f([self.weight, x1, x2])
+            else:
+                return self.f(self.weight, x1, x2)
         else:
             if weight is None:
                 raise ValueError(
                     "Internal weights are not used, weight should not be None"
                 )
             else:
-                return self.f([weight, x1, x2])
+                return self.f(weight, x1, x2)

--- a/cuequivariance_torch/cuequivariance_torch/operations/tp_fully_connected.py
+++ b/cuequivariance_torch/cuequivariance_torch/operations/tp_fully_connected.py
@@ -138,11 +138,11 @@ class FullyConnectedTensorProduct(torch.nn.Module):
         if self.weight is not None:
             if weight is not None:
                 raise ValueError("Internal weights are used, weight should be None")
-            return self.f([self.weight, x1, x2])
+            return self.f(self.weight, x1, x2)
         else:
             if weight is None:
                 raise ValueError(
                     "Internal weights are not used, weight should not be None"
                 )
             else:
-                return self.f([weight, x1, x2])
+                return self.f(weight, x1, x2)

--- a/cuequivariance_torch/cuequivariance_torch/primitives/equivariant_tensor_product.py
+++ b/cuequivariance_torch/cuequivariance_torch/primitives/equivariant_tensor_product.py
@@ -267,13 +267,9 @@ class EquivariantTensorProduct(torch.nn.Module):
             and not torch.jit.is_tracing()
             and not torch.compiler.is_compiling()
         ):
-            if not isinstance(inputs, (list, tuple)):
-                raise ValueError(
-                    "inputs should be a list of tensors followed by optional indices"
-                )
             if len(inputs) != self.etp.num_inputs:
                 raise ValueError(
-                    f"Expected {self.etp.num_inputs} inputs, got {len(inputs)}"
+                    f"Expected {self.etp.num_inputs} input tensors, got {len(inputs)}"
                 )
             for oid, input in enumerate(inputs):
                 torch._assert(

--- a/cuequivariance_torch/cuequivariance_torch/primitives/equivariant_tensor_product.py
+++ b/cuequivariance_torch/cuequivariance_torch/primitives/equivariant_tensor_product.py
@@ -130,14 +130,14 @@ class EquivariantTensorProduct(torch.nn.Module):
         >>> x1 = torch.ones(17, e.inputs[1].dim, device=device)
         >>> x2 = torch.ones(17, e.inputs[2].dim, device=device)
         >>> tp = cuet.EquivariantTensorProduct(e, layout=cue.ir_mul, device=device)
-        >>> tp([w, x1, x2])
+        >>> tp(w, x1, x2)
         tensor([[0., 0., 0., 0., 0., 0.],...)
 
         You can optionally index the first input tensor:
 
         >>> w = torch.ones(3, e.inputs[0].dim, device=device)
         >>> indices = torch.randint(3, (17,))
-        >>> tp([w, x1, x2], indices=indices)
+        >>> tp(w, x1, x2, indices=indices)
         tensor([[0., 0., 0., 0., 0., 0.],...)
     """
 

--- a/cuequivariance_torch/cuequivariance_torch/primitives/symmetric_tensor_product.py
+++ b/cuequivariance_torch/cuequivariance_torch/primitives/symmetric_tensor_product.py
@@ -356,7 +356,13 @@ class FallbackImpl(torch.nn.Module):
         outs: List[torch.Tensor] = []
 
         for f in self.fs:
-            if f.num_operands == 5:
+            if f.num_operands == 8:
+                outs.append(f(x0[i0], x1, x1, x1, x1, x1, x1))
+            elif f.num_operands == 7:
+                outs.append(f(x0[i0], x1, x1, x1, x1, x1))
+            elif f.num_operands == 6:
+                outs.append(f(x0[i0], x1, x1, x1, x1))
+            elif f.num_operands == 5:
                 outs.append(f(x0[i0], x1, x1, x1))
             elif f.num_operands == 4:
                 outs.append(f(x0[i0], x1, x1))

--- a/cuequivariance_torch/cuequivariance_torch/primitives/symmetric_tensor_product.py
+++ b/cuequivariance_torch/cuequivariance_torch/primitives/symmetric_tensor_product.py
@@ -356,7 +356,16 @@ class FallbackImpl(torch.nn.Module):
     def forward(
         self, x0: torch.Tensor, i0: torch.Tensor, x1: torch.Tensor
     ) -> torch.Tensor:
-        fs: List[torch.Tensor] = [
-            f([x0[i0]] + [x1] * (f.num_operands - 2)) for f in self.fs
-        ]
+        fs: List[torch.Tensor] = []
+
+        for f in self.fs:
+            if f.num_operands == 5:
+                fs.append(f(x0[i0], x1, x1, x1))
+            elif f.num_operands == 4:
+                fs.append(f(x0[i0], x1, x1))
+            elif f.num_operands == 3:
+                fs.append(f(x0[i0], x1))
+            else:
+                fs.append(f(x0[i0]))
+
         return torch.sum(torch.stack(fs), dim=0)

--- a/cuequivariance_torch/cuequivariance_torch/primitives/symmetric_tensor_product.py
+++ b/cuequivariance_torch/cuequivariance_torch/primitives/symmetric_tensor_product.py
@@ -344,10 +344,7 @@ class FallbackImpl(torch.nn.Module):
         self.fs = torch.nn.ModuleList(
             [
                 cuet.TensorProduct(
-                    d,
-                    device=device,
-                    math_dtype=math_dtype,
-                    use_fallback=True,
+                    d, device=device, math_dtype=math_dtype, use_fallback=True
                 )
                 for d in stps
             ]
@@ -356,16 +353,16 @@ class FallbackImpl(torch.nn.Module):
     def forward(
         self, x0: torch.Tensor, i0: torch.Tensor, x1: torch.Tensor
     ) -> torch.Tensor:
-        fs: List[torch.Tensor] = []
+        outs: List[torch.Tensor] = []
 
         for f in self.fs:
             if f.num_operands == 5:
-                fs.append(f(x0[i0], x1, x1, x1))
+                outs.append(f(x0[i0], x1, x1, x1))
             elif f.num_operands == 4:
-                fs.append(f(x0[i0], x1, x1))
+                outs.append(f(x0[i0], x1, x1))
             elif f.num_operands == 3:
-                fs.append(f(x0[i0], x1))
+                outs.append(f(x0[i0], x1))
             else:
-                fs.append(f(x0[i0]))
+                outs.append(f(x0[i0]))
 
-        return torch.sum(torch.stack(fs), dim=0)
+        return torch.sum(torch.stack(outs), dim=0)

--- a/cuequivariance_torch/cuequivariance_torch/primitives/tensor_product.py
+++ b/cuequivariance_torch/cuequivariance_torch/primitives/tensor_product.py
@@ -109,12 +109,14 @@ class TensorProduct(torch.nn.Module):
         x1: Optional[torch.Tensor] = None,
         x2: Optional[torch.Tensor] = None,
         x3: Optional[torch.Tensor] = None,
+        x4: Optional[torch.Tensor] = None,
+        x5: Optional[torch.Tensor] = None,
     ):
         r"""
         Perform the tensor product based on the specified descriptor.
 
         Args:
-            x0, x1[, x2, x3]: The input tensors. The number of input tensors should match the number of operands in the descriptor minus one.
+            x0, x1[, x2, x3, x4, x5]: The input tensors. The number of input tensors should match the number of operands in the descriptor minus one.
                 Each input tensor should have a shape of (batch, operand_size) or (1, operand_size)
                 where `operand_size` corresponds to the size of each operand as defined in
                 the tensor product descriptor.
@@ -126,7 +128,17 @@ class TensorProduct(torch.nn.Module):
                 `last_operand_size` is the size of the last operand in the descriptor.
         """
 
-        if x3 is not None and x2 is not None and x1 is not None:
+        if (
+            x5 is not None
+            and x4 is not None
+            and x3 is not None
+            and x2 is not None
+            and x1 is not None
+        ):
+            inputs = [x0, x1, x2, x3, x4, x5]
+        elif x4 is not None and x3 is not None and x2 is not None and x1 is not None:
+            inputs = [x0, x1, x2, x3, x4]
+        elif x3 is not None and x2 is not None and x1 is not None:
             inputs = [x0, x1, x2, x3]
         elif x2 is not None and x1 is not None:
             inputs = [x0, x1, x2]

--- a/cuequivariance_torch/cuequivariance_torch/primitives/tensor_product.py
+++ b/cuequivariance_torch/cuequivariance_torch/primitives/tensor_product.py
@@ -68,6 +68,7 @@ class TensorProduct(torch.nn.Module):
             math_dtype = torch.get_default_dtype()
 
         self.has_cuda = False
+        self.f = None
         self.num_operands = descriptor.num_operands
 
         if use_fallback is False:
@@ -88,8 +89,10 @@ class TensorProduct(torch.nn.Module):
                     "pip install cuequivariance-ops-torch-cu12"
                 )
 
-        if not self.has_cuda:
+        if self.f is None:
             self.f = _tensor_product_fx(descriptor, device, math_dtype, True)
+
+        self.f = _Wrapper(self.f, descriptor)
 
         self.operands_dims = [ope.size for ope in descriptor.operands]
 
@@ -100,12 +103,18 @@ class TensorProduct(torch.nn.Module):
         )
         return f"TensorProduct({self.descriptor} {has_cuda_kernel})"
 
-    def forward(self, inputs: List[torch.Tensor]):
+    def forward(
+        self,
+        x0: torch.Tensor,
+        x1: Optional[torch.Tensor] = None,
+        x2: Optional[torch.Tensor] = None,
+        x3: Optional[torch.Tensor] = None,
+    ):
         r"""
         Perform the tensor product based on the specified descriptor.
 
         Args:
-            inputs (list of torch.Tensor): The input tensors. The number of input tensors should match the number of operands in the descriptor minus one.
+            x0, x1[, x2, x3]: The input tensors. The number of input tensors should match the number of operands in the descriptor minus one.
                 Each input tensor should have a shape of (batch, operand_size) or (1, operand_size)
                 where `operand_size` corresponds to the size of each operand as defined in
                 the tensor product descriptor.
@@ -116,13 +125,21 @@ class TensorProduct(torch.nn.Module):
                 It has a shape of (batch, last_operand_size), where
                 `last_operand_size` is the size of the last operand in the descriptor.
         """
+
+        if x3 is not None and x2 is not None and x1 is not None:
+            inputs = [x0, x1, x2, x3]
+        elif x2 is not None and x1 is not None:
+            inputs = [x0, x1, x2]
+        elif x1 is not None:
+            inputs = [x0, x1]
+        else:
+            inputs = [x0]
+
         if (
             not torch.jit.is_scripting()
             and not torch.jit.is_tracing()
             and not torch.compiler.is_compiling()
         ):
-            if not isinstance(inputs, (list, tuple)):
-                raise ValueError("inputs should be a list of tensors")
             if len(inputs) != self.num_operands - 1:
                 raise ValueError(
                     f"Expected {self.num_operands - 1} input tensors, got {len(inputs)}"
@@ -183,8 +200,7 @@ def _tensor_product_fx(
             torch.fx.Proxy(graph.placeholder(f"input_{i}"), tracer)
             for i in range(num_inputs)
         ]
-        for input in inputs:
-            torch._assert(input.ndim == 2, "input should have ndim=2")
+
         operand_subscripts = [
             f"Z{operand.subscripts}" for operand in descriptor.operands
         ]
@@ -308,7 +324,7 @@ def _tensor_product_fx(
             "No FX implementation for empty paths and non-empty inputs"
         )
 
-    return _Wrapper(graphmod, descriptor)
+    return graphmod
 
 
 class _Caller(torch.nn.Module):
@@ -378,21 +394,6 @@ class _Wrapper(torch.nn.Module):
         self.descriptor = descriptor
 
     def forward(self, args: List[torch.Tensor]):
-        if (
-            not torch.jit.is_scripting()
-            and not torch.jit.is_tracing()
-            and not torch.compiler.is_compiling()
-        ):
-            for oid, arg in enumerate(args):
-                torch._assert(
-                    arg.ndim == 2,
-                    f"input {oid} should have ndim=2",
-                )
-                torch._assert(
-                    arg.shape[1] == self.descriptor.operands[oid].size,
-                    f"input {oid} should have shape (batch, {self.descriptor.operands[oid].size})",
-                )
-
         return self.module(args)
 
 
@@ -511,8 +512,8 @@ class FusedTensorProductOp3(torch.nn.Module):
     def __repr__(self) -> str:
         return f"FusedTensorProductOp3({self.descriptor} (output last operand))"
 
-    def forward(self, inputs: List[torch.Tensor]) -> torch.Tensor:
-        x0, x1 = self._perm(inputs[0], inputs[1])
+    def forward(self, x0: torch.Tensor, x1: torch.Tensor) -> torch.Tensor:
+        x0, x1 = self._perm(x0, x1)
 
         if (
             not torch.jit.is_scripting()
@@ -576,8 +577,10 @@ class FusedTensorProductOp4(torch.nn.Module):
     def __repr__(self) -> str:
         return f"FusedTensorProductOp4({self.descriptor} (output last operand))"
 
-    def forward(self, inputs: List[torch.Tensor]) -> torch.Tensor:
-        x0, x1, x2 = self._perm(inputs[0], inputs[1], inputs[2])
+    def forward(
+        self, x0: torch.Tensor, x1: torch.Tensor, x2: torch.Tensor
+    ) -> torch.Tensor:
+        x0, x1, x2 = self._perm(x0, x1, x2)
 
         if (
             not torch.jit.is_scripting()
@@ -639,9 +642,7 @@ class TensorProductUniform3x1d(TensorProductUniform1d):
     def __repr__(self):
         return f"TensorProductUniform3x1d({self.descriptor} (output last operand))"
 
-    def forward(self, inputs: List[torch.Tensor]) -> torch.Tensor:
-        x0, x1 = inputs
-
+    def forward(self, x0: torch.Tensor, x1: torch.Tensor) -> torch.Tensor:
         if (
             not torch.jit.is_scripting()
             and not torch.jit.is_tracing()
@@ -650,7 +651,6 @@ class TensorProductUniform3x1d(TensorProductUniform1d):
             logger.debug(
                 f"Calling TensorProductUniform3x1d: {self.descriptor}, input shapes: {x0.shape}, {x1.shape}"
             )
-
         torch._assert(x0.ndim == 2, "input should be (batch, dim) or (1, dim)")
         torch._assert(x1.ndim == 2, "input should be (batch, dim) or (1, dim)")
 
@@ -664,9 +664,9 @@ class TensorProductUniform4x1d(TensorProductUniform1d):
     def __repr__(self):
         return f"TensorProductUniform4x1d({self.descriptor} (output last operand))"
 
-    def forward(self, inputs: List[torch.Tensor]):
-        x0, x1, x2 = inputs
-
+    def forward(
+        self, x0: torch.Tensor, x1: torch.Tensor, x2: torch.Tensor
+    ) -> torch.Tensor:
         if (
             not torch.jit.is_scripting()
             and not torch.jit.is_tracing()
@@ -675,7 +675,6 @@ class TensorProductUniform4x1d(TensorProductUniform1d):
             logger.debug(
                 f"Calling TensorProductUniform4x1d: {self.descriptor}, input shapes: {x0.shape}, {x1.shape}, {x2.shape}"
             )
-
         torch._assert(x0.ndim == 2, "input should be (batch, dim) or (1, dim)")
         torch._assert(x1.ndim == 2, "input should be (batch, dim) or (1, dim)")
         torch._assert(x2.ndim == 2, "input should be (batch, dim) or (1, dim)")

--- a/cuequivariance_torch/cuequivariance_torch/primitives/tensor_product.py
+++ b/cuequivariance_torch/cuequivariance_torch/primitives/tensor_product.py
@@ -111,12 +111,13 @@ class TensorProduct(torch.nn.Module):
         x3: Optional[torch.Tensor] = None,
         x4: Optional[torch.Tensor] = None,
         x5: Optional[torch.Tensor] = None,
+        x6: Optional[torch.Tensor] = None,
     ):
         r"""
         Perform the tensor product based on the specified descriptor.
 
         Args:
-            x0, x1[, x2, x3, x4, x5]: The input tensors. The number of input tensors should match the number of operands in the descriptor minus one.
+            x0, x1[, x2, x3, x4, x5, x6]: The input tensors. The number of input tensors should match the number of operands in the descriptor minus one.
                 Each input tensor should have a shape of (batch, operand_size) or (1, operand_size)
                 where `operand_size` corresponds to the size of each operand as defined in
                 the tensor product descriptor.
@@ -129,6 +130,15 @@ class TensorProduct(torch.nn.Module):
         """
 
         if (
+            x6 is not None
+            and x5 is not None
+            and x4 is not None
+            and x3 is not None
+            and x2 is not None
+            and x1 is not None
+        ):
+            inputs = [x0, x1, x2, x3, x4, x5, x6]
+        elif (
             x5 is not None
             and x4 is not None
             and x3 is not None

--- a/cuequivariance_torch/tests/operations/tp_channel_wise_test.py
+++ b/cuequivariance_torch/tests/operations/tp_channel_wise_test.py
@@ -75,7 +75,7 @@ def test_channel_wise_fwd(
     if layout == cue.mul_ir:
         d = d.add_or_transpose_modes("u,ui,j,uk+ijk")
     m2 = cuet.TensorProduct(d, math_dtype=torch.float64, use_fallback=True).to(device)
-    out2 = m2([m1.weight, x1, x2])
+    out2 = m2(m1.weight, x1, x2)
 
     torch.testing.assert_close(out1, out2, atol=1e-5, rtol=1e-5)
 

--- a/cuequivariance_torch/tests/operations/tp_fully_connected_test.py
+++ b/cuequivariance_torch/tests/operations/tp_fully_connected_test.py
@@ -75,7 +75,9 @@ def test_fully_connected(
         d = d.add_or_transpose_modes("uvw,ui,vj,wk+ijk")
     m2 = cuet.TensorProduct(d, math_dtype=torch.float64, use_fallback=True).to(device)
     out2 = m2(
-        [m1.weight.to(torch.float64), x1.to(torch.float64), x2.to(torch.float64)],
+        m1.weight.to(torch.float64),
+        x1.to(torch.float64),
+        x2.to(torch.float64),
     ).to(out1.dtype)
 
     torch.testing.assert_close(out1, out2, atol=1e-5, rtol=1e-5)

--- a/cuequivariance_torch/tests/primitives/primitive_export_test.py
+++ b/cuequivariance_torch/tests/primitives/primitive_export_test.py
@@ -60,10 +60,13 @@ def test_script_fused_tp_3(mode, tmp_path):
     x1 = torch.randn(batch, d.operands[1].size, device=device, dtype=torch.float32)
     inputs = [x0, x1]
     m = FusedTensorProductOp3(d, (0, 1), device, torch.float32)
-    module = module_with_mode(mode, m, (inputs,), torch.float32, tmp_path)
-    out1 = m(inputs)
-    out2 = module(inputs)
+    module = module_with_mode(mode, m, inputs, torch.float32, tmp_path)
+    out1 = m(*inputs)
+    out2 = module(*inputs)
     torch.testing.assert_close(out1, out2)
+
+
+export_modes = ["script", "export"]
 
 
 @pytest.mark.parametrize("mode", export_modes)
@@ -87,9 +90,9 @@ def test_script_fused_tp_4(mode, tmp_path):
 
     inputs = [x0, x1, x2]
     m = FusedTensorProductOp4(d, [0, 1, 2], device, torch.float32)
-    module = module_with_mode(mode, m, (inputs,), torch.float32, tmp_path)
-    out1 = m(inputs)
-    out2 = module(inputs)
+    module = module_with_mode(mode, m, inputs, torch.float32, tmp_path)
+    out1 = m(*inputs)
+    out2 = module(*inputs)
     torch.testing.assert_close(out1, out2)
 
 
@@ -112,9 +115,9 @@ def test_script_uniform_tp_3(mode, tmp_path):
     inputs = [x0, x1]
 
     m = TensorProductUniform3x1d(d, device, torch.float32)
-    module = module_with_mode(mode, m, (inputs,), torch.float32, tmp_path)
-    out1 = m(inputs)
-    out2 = module(inputs)
+    module = module_with_mode(mode, m, inputs, torch.float32, tmp_path)
+    out1 = m(*inputs)
+    out2 = module(*inputs)
     torch.testing.assert_close(out1, out2)
 
 
@@ -138,7 +141,7 @@ def test_script_uniform_tp_4(mode, tmp_path):
     inputs = [x0, x1, x2]
 
     m = TensorProductUniform4x1d(d, device, torch.float32)
-    module = module_with_mode(mode, m, (inputs,), torch.float32, tmp_path)
-    out1 = m(inputs)
-    out2 = module(inputs)
+    module = module_with_mode(mode, m, inputs, torch.float32, tmp_path)
+    out1 = m(*inputs)
+    out2 = module(*inputs)
     torch.testing.assert_close(out1, out2)

--- a/docs/tutorials/etp.rst
+++ b/docs/tutorials/etp.rst
@@ -94,6 +94,6 @@ We can execute an :class:`cuequivariance.EquivariantTensorProduct` with PyTorch.
     w = torch.randn(1, e.inputs[0].dim)
     x = torch.randn(1, e.inputs[1].dim)
 
-    module([w, x])
+    module(w, x)
 
 Note that you have to specify the layout. If the layout specified is different from the one in the descriptor, the module will transpose the inputs/output to match the layout.

--- a/docs/tutorials/stp.rst
+++ b/docs/tutorials/stp.rst
@@ -112,7 +112,7 @@ Now we can execute the linear layer with random input and weight tensors.
    w = torch.randn(1, d.operands[0].size)
    x1 = torch.randn(3000, irreps1.dim)
 
-   x2 = linear_torch([w, x1])
+   x2 = linear_torch(w, x1)
 
    assert x2.shape == (3000, irreps2.dim)
 


### PR DESCRIPTION
Back to non-lists API
Good news - it's still script-compliant, too :)
