### PR TITLE
Refactor tensor_product to use jax.extend.core for Primitive

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.2  # Use the latest stable version of Black
+    rev: v0.9.1
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/cuequivariance_jax/cuequivariance_jax/primitives/equivariant_tensor_product.py
+++ b/cuequivariance_jax/cuequivariance_jax/primitives/equivariant_tensor_product.py
@@ -87,16 +87,16 @@ def equivariant_tensor_product(
 
     for i, (x, rep) in enumerate(zip(inputs, e.inputs)):
         if isinstance(x, cuex.RepArray):
-            assert (
-                x.rep(-1) == rep
-            ), f"Input {i} should have representation {rep}, got {x.rep(-1)}."
+            assert x.rep(-1) == rep, (
+                f"Input {i} should have representation {rep}, got {x.rep(-1)}."
+            )
         else:
-            assert (
-                x.ndim >= 1
-            ), f"Input {i} should have at least one dimension, got {x.ndim}."
-            assert (
-                x.shape[-1] == rep.dim
-            ), f"Input {i} should have dimension {rep.dim}, got {x.shape[-1]}."
+            assert x.ndim >= 1, (
+                f"Input {i} should have at least one dimension, got {x.ndim}."
+            )
+            assert x.shape[-1] == rep.dim, (
+                f"Input {i} should have dimension {rep.dim}, got {x.shape[-1]}."
+            )
             if not rep.is_scalar():
                 raise ValueError(
                     f"Input {i} should be a RepArray unless the input is scalar. Got {type(x)} for {rep}."


### PR DESCRIPTION
```
cuequivariance_jax/cuequivariance_jax/primitives/tensor_product.py:163
    DeprecationWarning: jax.core.Primitive is deprecated. Use jax.extend.core.Primitive instead, and see https://jax.readthedocs.io/en/latest/jax.extend.html for details.
    tensor_product_p = core.Primitive("tensor_product")
```