### PR TITLE
[JAX] make trimul cache name/keys similar to their torch counterpart

### DIFF
--- a/cuequivariance_torch/cuequivariance_torch/primitives/segmented_polynomial_uniform_1d.py
+++ b/cuequivariance_torch/cuequivariance_torch/primitives/segmented_polynomial_uniform_1d.py
@@ -59,7 +59,7 @@ try:
             batch_size: int,
             tensors: List[torch.Tensor],
         ) -> List[torch.Tensor]:
-            return torch.ops.cuequivariance_ops.tensor_product_uniform_1d_jit(
+            return torch.ops.cuequivariance.tensor_product_uniform_1d_jit(
                 name,
                 math_dtype,
                 operand_extent,

--- a/cuequivariance_torch/cuequivariance_torch/primitives/triangle.py
+++ b/cuequivariance_torch/cuequivariance_torch/primitives/triangle.py
@@ -12,14 +12,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Optional, Tuple
+from typing import Optional, Tuple
 
 import torch
 
 try:
     from cuequivariance_ops_torch import TriMulPrecision
 except ImportError:
-    TriMulPrecision = Any  # type: ignore
+    import enum
+
+    class TriMulPrecision(enum.IntEnum):  # type: ignore
+        """Fallback precision enum when cuequivariance_ops_torch is not available."""
+
+        NONE = -1
+        DEFAULT = 0
+        TF32 = 1
+        TF32x3 = 2
+        IEEE = 3
 
 
 def triangle_attention(


### PR DESCRIPTION
Make JAX implementation of trimul able to load the same cache files used in the counterpart pytorch code.