### PR TITLE
api: remove dim_order from triangle_attention

### DIFF
--- a/cuequivariance_jax/cuequivariance_jax/triangle/_triangle_attention.py
+++ b/cuequivariance_jax/cuequivariance_jax/triangle/_triangle_attention.py
@@ -47,7 +47,8 @@ def triangle_attention(
         q: Query tensor of shape [B, N, H, S_qo, D].
         k: Key tensor of shape [B, N, H, S_kv, D].
         v: Value tensor of shape [B, N, H, S_kv, D].
-        bias: Bias tensor of shape [B, 1, H, S_qo, S_kv].
+        bias: Bias tensor of shape [B, 1, H, S_qo, S_kv]. Cast to float32 for standard
+            kernels; on Blackwell GPUs (sm100f), cast to match q/k/v dtype (bf16/fp16).
         mask: Mask tensor of shape [B, N, 1, 1, S_kv] (boolean, True means valid).
         scale: Scaling factor for the dot product.
         precision: Precision for the computation (default is None).
@@ -68,6 +69,12 @@ def triangle_attention(
         Without explicit sharding, performance will be significantly degraded. See
         `JAX shard_map documentation <https://docs.jax.dev/en/latest/notebooks/shard_map.html>`_
         for details on manual parallelism.
+
+    .. note::
+        On Blackwell GPUs (cc 10.0 or 10.3, cu13 builds), the sm100f kernel supports
+        hidden_dim<=256 for forward and hidden_dim<=128 for backward passes (bf16/fp16
+        only; hidden_dim must be divisible by 8). The sm100f forward kernel requires
+        S_kv to be a multiple of 8.
     """
     return triangle_attention_custom_vjp(
         q, k, v, bias, mask, scale=scale, precision=precision

--- a/cuequivariance_torch/cuequivariance_torch/primitives/triangle.py
+++ b/cuequivariance_torch/cuequivariance_torch/primitives/triangle.py
@@ -39,7 +39,6 @@ def triangle_attention(
     mask: Optional[torch.Tensor] = None,
     scale: Optional[float] = None,
     return_aux: bool = False,
-    dim_order: Optional[Tuple[int, int, int, int, int]] = None,
 ) -> torch.Tensor | Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     r"""
     Triangle Attention
@@ -57,18 +56,14 @@ def triangle_attention(
         k (torch.Tensor): Key tensor of shape (B, N, H, K, D). For B=1, can also be (N, H, K, D).
         v (torch.Tensor): Value tensor of shape (B, N, H, K, D). For B=1, can also be (N, H, K, D).
         bias (torch.Tensor): Bias tensor of shape (B, 1, H, Q, K), For B=1, can also be (1, H, Q, K).
-            Will be cast to float32 internally.
+            Will be cast to float32 for standard kernels. On Blackwell GPUs (sm100f, compute
+            capability 10.0 or 10.3), will be cast to match q/k/v dtype (bf16/fp16) for best
+            performance.
         mask (torch.Tensor, optional): Mask tensor of shape (B, N, 1, 1, K). For B=1, can also be (N, 1, 1, K).
             Will be cast to bool internally.
         scale (float, optional): Float scale for q (s in the equation). If None, value 1/sqrt(d) is used.
         return_aux (bool): If True, two auxiliary tensors are returned along with the result.
             Defaults to False.
-        dim_order (tuple of 5 ints, optional): Permutation of (0,1,2,3,4) specifying how to
-            reorder the axes of q/k/v/bias from the user's layout to the kernel's [B,N,H,Q,D]
-            layout. This is an O(1) metadata-only permute (no data copy) and incurs zero
-            overhead when the resulting tensor already satisfies sm100f TMA alignment
-            constraints. Example: ``dim_order=(0,1,3,2,4)`` for tensors stored as
-            [B,N,Q,H,D] (H/Q swapped). Defaults to None (no reordering).
 
     Note:
         - B: batch size
@@ -86,7 +81,7 @@ def triangle_attention(
     Notes:
         (1) Context is saved for backward pass. You don't need to save it manually.
         (2) Kernel precision (fp32, bf16, fp16) is based on input dtypes. For tf32, set it from torch global scope
-        (3) Triangle attention kernel supports: all hidden_dim<=32 and divisible by 4 for tf32/fp32, and for all hidden_dim<=128 and divisible by 8 for bf16/fp16. In the rare instance that the kernel does not support an input config, fallback to torch is enabled instead of erroring out.
+        (3) Triangle attention kernel supports: all hidden_dim<=32 and divisible by 4 for tf32/fp32, and for all hidden_dim<=128 and divisible by 8 for bf16/fp16 (standard kernels). On Blackwell GPUs (compute capability 10.0 or 10.3), the sm100f kernel supports hidden_dim<=256 for forward passes and hidden_dim<=128 for backward passes. In the rare instance that the kernel does not support an input config, fallback to torch is enabled instead of erroring out.
         (4) Blackwell-optimized kernels (for compute capabilities 10.0 and 10.3) provide superior performance especially for long sequences and higher head dimensions. These kernels require the sequence length N to be a multiple of 8 for the forward pass; pad the sequence if necessary. Currently, this feature is supported only for cu13 builds.
 
     Example:
@@ -137,7 +132,7 @@ def triangle_attention(
             "Error importing triangle_attention from cuequivariance_ops_torch."
         )
     else:
-        return f(q, k, v, bias, mask, scale, return_aux, dim_order)
+        return f(q, k, v, bias, mask, scale, return_aux)
 
 
 def triangle_multiplicative_update(


### PR DESCRIPTION
## Summary
- Remove `dim_order` parameter from `triangle_attention` API signature
- Remove corresponding `dim_order` docstring entry
- Remove `dim_order` from the underlying ops call

## Test plan
- [x] Pre-commit (ruff lint + format) passes
- [x] Verify `triangle_attention` callers do not pass `dim_order`