### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Description
+
+<!-- Describe what this PR changes and why. Link to the tracking issue. -->
+
+Closes #
+
+## Checklist
+
+Please confirm the following before requesting review. PRs that do not meet these requirements cannot be merged. See [CONTRIBUTING.md](https://github.com/NVIDIA/cuEquivariance/blob/main/CONTRIBUTING.md) for the full contribution rules.
+
+### Contribution rules
+
+- [ ] I have read and am adhering to the [Contribution Rules](https://github.com/NVIDIA/cuEquivariance/blob/main/CONTRIBUTING.md).
+- [ ] An [issue](https://github.com/NVIDIA/cuEquivariance/issues) was filed and approved by the NVIDIA team before this PR.
+- [ ] I have installed and run [`pre-commit`](https://pre-commit.com/) locally (`pip install pre-commit && pre-commit install`).
+- [ ] This PR addresses a single concern and avoids unnecessary complexity or commented-out code.
+- [ ] If this PR is a work in progress, the title is prefixed with `[WIP]`.
+
+### Sign-off (DCO)
+
+Per [Signing Your Work](https://github.com/NVIDIA/cuEquivariance/blob/main/CONTRIBUTING.md#signing-your-work), every commit in this PR must be signed off with `git commit -s` (appending `Signed-off-by: Your Name <your@email.com>`). PRs containing unsigned commits will not be accepted.
+
+- [ ] All commits in this PR are signed off (`git commit -s`).
+- [ ] By signing off, I certify that I have the right to submit this contribution under the project's open source license, in accordance with the [Developer Certificate of Origin v1.1](https://github.com/NVIDIA/cuEquivariance/blob/main/CONTRIBUTING.md#full-text-of-the-dco).


### PR DESCRIPTION
## Summary

Adds `.github/PULL_REQUEST_TEMPLATE.md` so every new PR auto-populates with a checklist that asks the contributor to confirm:

- They are adhering to the rules in [CONTRIBUTING.md](https://github.com/NVIDIA/cuEquivariance/blob/main/CONTRIBUTING.md) (issue-first workflow, pre-commit, single-concern PRs, `[WIP]` titles for drafts).
- All commits are signed off per the [DCO](https://github.com/NVIDIA/cuEquivariance/blob/main/CONTRIBUTING.md#signing-your-work) (`git commit -s`).

## Why

Makes the contribution rules and DCO sign-off requirement visible at PR-open time rather than relying on contributors to read CONTRIBUTING.md before opening.

## Test plan

- [ ] After merge, open a fresh PR against this repo and verify the template appears pre-filled in the description box.