### PR TITLE
test: enable trace_autograd_ops for torch 2.11 compile/export

### DIFF
--- a/cuequivariance_torch/tests/conftest.py
+++ b/cuequivariance_torch/tests/conftest.py
@@ -14,6 +14,14 @@
 # limitations under the License.
 import pytest
 import torch
+import torch._dynamo
+
+# torch 2.11+ no longer honors allow_in_graph for torch.autograd.grad; it gates
+# tracing through it under torch.compile/export behind this config flag. Several
+# tests (e.g. segmented_polynomial in compile/export modes) call torch.autograd.grad
+# inside a compiled module, so enable it session-wide. Guarded for older torch.
+if hasattr(torch._dynamo.config, "trace_autograd_ops"):
+    torch._dynamo.config.trace_autograd_ops = True
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
torch 2.11 no longer honors torch._dynamo.allow_in_graph for torch.autograd.grad; tracing it under torch.compile/export now requires torch._dynamo.config.trace_autograd_ops=True, otherwise Dynamo raises torch._dynamo.exc.Unsupported. The segmented_polynomial tests call torch.autograd.grad inside compiled/exported modules and fail on 2.11.

Set the flag session-wide in the torch tests' conftest (guarded with hasattr so older torch is unaffected).

## Description

<!-- Describe what this PR changes and why. Link to the tracking issue. -->

Closes #

## Checklist

Please confirm the following before requesting review. PRs that do not meet these requirements cannot be merged. See [CONTRIBUTING.md](https://github.com/NVIDIA/cuEquivariance/blob/main/CONTRIBUTING.md) for the full contribution rules.

### Contribution rules

- [ ] I have read and am adhering to the [Contribution Rules](https://github.com/NVIDIA/cuEquivariance/blob/main/CONTRIBUTING.md).
- [ ] An [issue](https://github.com/NVIDIA/cuEquivariance/issues) was filed and approved by the NVIDIA team before this PR.
- [ ] I have installed and run [`pre-commit`](https://pre-commit.com/) locally (`pip install pre-commit && pre-commit install`).
- [ ] This PR addresses a single concern and avoids unnecessary complexity or commented-out code.
- [ ] If this PR is a work in progress, the title is prefixed with `[WIP]`.

### Sign-off (DCO)

Per [Signing Your Work](https://github.com/NVIDIA/cuEquivariance/blob/main/CONTRIBUTING.md#signing-your-work), every commit in this PR must be signed off with `git commit -s` (appending `Signed-off-by: Your Name <your@email.com>`). PRs containing unsigned commits will not be accepted.

- [ ] All commits in this PR are signed off (`git commit -s`).
- [ ] By signing off, I certify that I have the right to submit this contribution under the project's open source license, in accordance with the [Developer Certificate of Origin v1.1](https://github.com/NVIDIA/cuEquivariance/blob/main/CONTRIBUTING.md#full-text-of-the-dco).
