### PR TITLE
BIO-714: expose + document MXFP8 TriMulPrecision in OSS frontend

### DIFF
--- a/cuequivariance_torch/cuequivariance_torch/primitives/triangle.py
+++ b/cuequivariance_torch/cuequivariance_torch/primitives/triangle.py
@@ -35,8 +35,8 @@ except ImportError:
         TF32x3 = 2
         IEEE = 3
         # Tri-mul carrier-precision modes (opt-in; default is None = off).
-        MXFP8 = -1000
-        BFLOAT16 = -1001
+        MXFP8 = 4
+        BFLOAT16 = 5
 
 
 def triangle_attention(

--- a/cuequivariance_torch/cuequivariance_torch/primitives/triangle.py
+++ b/cuequivariance_torch/cuequivariance_torch/primitives/triangle.py
@@ -22,13 +22,21 @@ except ImportError:
     import enum
 
     class TriMulPrecision(enum.IntEnum):  # type: ignore
-        """Fallback precision enum when cuequivariance_ops_torch is not available."""
+        """Fallback precision enum when cuequivariance_ops_torch is not available.
+
+        Values must match ``cuequivariance_ops_torch.TriMulPrecision`` so that
+        ``precision=TriMulPrecision.MXFP8`` resolves identically whether or not
+        the backend ops package is installed.
+        """
 
         NONE = -1
         DEFAULT = 0
         TF32 = 1
         TF32x3 = 2
         IEEE = 3
+        # Tri-mul carrier-precision modes (opt-in; default is None = off).
+        MXFP8 = -1000
+        BFLOAT16 = -1001
 
 
 def triangle_attention(
@@ -197,6 +205,9 @@ def triangle_multiplicative_update(
             Available options:
             - None: Defaults to triton language dot's default for non-32b input and for 32b input, tf32/tf32x3 based on 1/0 value set in torch.backends.cuda.matmul.allow_tf32
             - IEEE: Use IEEE 754 precision
+            - MXFP8: Opt-in MXFP8 (E4M3 + UE8M0 block scales) acceleration for the
+              triangular projection. **Inference-only and off by default** — see note (7).
+              Equivalent to passing the string ``"mxfp8"``.
 
     Returns:
         Output tensor of shape (batch_size, seq_len, seq_len, hidden_dim)
@@ -208,6 +219,18 @@ def triangle_multiplicative_update(
         (4) We have moved away from the default round-towards-zero (RZ) implementation to round-nearest (RN) for better tf32 accuracy in cuex.triangle_multiplicative_update. In rare circumstances, this may cause minor differences in results observed.
         (5) When using torch compile, use `cueuivariance_ops_torch.init_triton_cache()` to initialize triton cache before calling torch compiled triangular multiplicative update.
         (6) Although the example demonstrates the most common case of one batch dimension, the API supports variable number of leading batch dimensions.
+        (7) **MXFP8 precision** (``precision=TriMulPrecision.MXFP8`` or ``"mxfp8"``) is an
+            opt-in, **inference-only** acceleration of the triangular projection. It is
+            **off by default** (``precision=None``). It engages only when *all* of the
+            following hold, and otherwise transparently falls back to bf16 (no error):
+            - **Inference only**: any input has ``requires_grad=True`` (training) falls back
+              to bf16 with a warning. The MXFP8 backward path is not yet implemented.
+            - **Sequence length** must be divisible by 32 (``seq_len % 32 == 0``); other
+              lengths warn and fall back to bf16.
+            - **Hardware**: a Blackwell GPU (CUDA compute capability >= 10.0, e.g.
+              sm_100 / sm_103) with the CUTLASS MXFP8 binding available; on other GPUs it
+              falls back to bf16.
+            Numerics are MXFP8-quantized, so expect small deviations from the bf16/None path.
 
     Example:
         >>> import torch

--- a/cuequivariance_torch/tests/primitives/triangle_test.py
+++ b/cuequivariance_torch/tests/primitives/triangle_test.py
@@ -181,3 +181,41 @@ def test_attention_pair_bias():
             b_ln_z=b_ln_z,
         )
         assert output.shape == torch.Size([batch_size, seq_len, hidden_dim])
+
+
+def test_trimul_precision_mxfp8_enum_member():
+    # BIO-714: MXFP8 must be discoverable on the public TriMulPrecision enum, whether it
+    # is imported from the cuequivariance_ops_torch backend or resolved from the in-module
+    # fallback enum (no-ops-installed case). Both must carry the same sentinel values.
+    assert hasattr(cuet.TriMulPrecision, "MXFP8")
+    assert hasattr(cuet.TriMulPrecision, "BFLOAT16")
+    assert int(cuet.TriMulPrecision.MXFP8.value) == -1000
+    assert int(cuet.TriMulPrecision.BFLOAT16.value) == -1001
+
+
+def test_triangle_multiplicative_update_mxfp8_inference():
+    # BIO-714: exercise the opt-in, inference-only MXFP8 path via the enum member.
+    # seq_len is > the eager bf16-fallback threshold (150) and divisible by 32 so the
+    # optimized path engages; on a Blackwell GPU (cc >= 10.0) this hits the MXFP8 CUTLASS
+    # kernel, and on other GPUs it transparently falls back to bf16 (same output shape).
+    if not torch.cuda.is_available():
+        return
+    try:
+        import cuequivariance_ops_torch  # noqa: F401
+    except ImportError:
+        return  # backend ops not installed; the MXFP8 path is unavailable
+    device = torch.device("cuda")
+    batch_size, seq_len, hidden_dim = 1, 160, 32
+    expected = torch.Size([batch_size, seq_len, seq_len, hidden_dim])
+    with torch.no_grad():
+        x = torch.randn(batch_size, seq_len, seq_len, hidden_dim, device=device)
+        mask = torch.ones(batch_size, seq_len, seq_len, device=device)
+        # Both the enum member and the legacy string spelling select the same path.
+        for precision in (cuet.TriMulPrecision.MXFP8, "mxfp8"):
+            output = cuet.triangle_multiplicative_update(
+                x=x,
+                direction="outgoing",
+                mask=mask,
+                precision=precision,
+            )
+            assert output.shape == expected

--- a/cuequivariance_torch/tests/primitives/triangle_test.py
+++ b/cuequivariance_torch/tests/primitives/triangle_test.py
@@ -189,8 +189,8 @@ def test_trimul_precision_mxfp8_enum_member():
     # fallback enum (no-ops-installed case). Both must carry the same sentinel values.
     assert hasattr(cuet.TriMulPrecision, "MXFP8")
     assert hasattr(cuet.TriMulPrecision, "BFLOAT16")
-    assert int(cuet.TriMulPrecision.MXFP8.value) == -1000
-    assert int(cuet.TriMulPrecision.BFLOAT16.value) == -1001
+    assert int(cuet.TriMulPrecision.MXFP8.value) == 4
+    assert int(cuet.TriMulPrecision.BFLOAT16.value) == 5
 
 
 def test_triangle_multiplicative_update_mxfp8_inference():


### PR DESCRIPTION
Mirror MXFP8/BFLOAT16 into the fallback TriMulPrecision enum so precision=TriMulPrecision.MXFP8 resolves whether or not the cuequivariance_ops_torch backend is installed. Document the MXFP8 option in the triangle_multiplicative_update docstring as opt-in, inference-only, seq % 32 == 0, Blackwell-only (cc >= 10.0), with transparent bf16 fallback. Add frontend tests: an always-on enum-member check and a GPU-guarded MXFP8 inference exercise (string + enum paths).

Default stays precision=None (off); MXFP8 backward is not yet implemented.

## Description

<!-- Describe what this PR changes and why. Link to the tracking issue. -->

Closes #

## Checklist

Please confirm the following before requesting review. PRs that do not meet these requirements cannot be merged. See [CONTRIBUTING.md](https://github.com/NVIDIA/cuEquivariance/blob/main/CONTRIBUTING.md) for the full contribution rules.

### Contribution rules

- [ ] I have read and am adhering to the [Contribution Rules](https://github.com/NVIDIA/cuEquivariance/blob/main/CONTRIBUTING.md).
- [ ] An [issue](https://github.com/NVIDIA/cuEquivariance/issues) was filed and approved by the NVIDIA team before this PR.
- [ ] I have installed and run [`pre-commit`](https://pre-commit.com/) locally (`pip install pre-commit && pre-commit install`).
- [ ] This PR addresses a single concern and avoids unnecessary complexity or commented-out code.
- [ ] If this PR is a work in progress, the title is prefixed with `[WIP]`.

### Sign-off (DCO)

Per [Signing Your Work](https://github.com/NVIDIA/cuEquivariance/blob/main/CONTRIBUTING.md#signing-your-work), every commit in this PR must be signed off with `git commit -s` (appending `Signed-off-by: Your Name <your@email.com>`). PRs containing unsigned commits will not be accepted.

- [ ] All commits in this PR are signed off (`git commit -s`).
- [ ] By signing off, I certify that I have the right to submit this contribution under the project's open source license, in accordance with the [Developer Certificate of Origin v1.1](https://github.com/NVIDIA/cuEquivariance/blob/main/CONTRIBUTING.md#full-text-of-the-dco).
