### PR TITLE
test(jax): cover checkpointed triangle attention scan

### DIFF
--- a/cuequivariance_jax/cuequivariance_jax/triangle/_triangle_attention.py
+++ b/cuequivariance_jax/cuequivariance_jax/triangle/_triangle_attention.py
@@ -54,7 +54,8 @@ def triangle_attention(
         precision: Precision for the computation (default is None).
 
     Returns:
-        A tuple containing the attention output, log-sum-exp, and maximum value.
+        A three-element list containing the attention output, log-sum-exp, and
+        maximum value.
 
     .. math::
 

--- a/cuequivariance_jax/tests/triangle_attention_test.py
+++ b/cuequivariance_jax/tests/triangle_attention_test.py
@@ -102,6 +102,31 @@ def test_gradient_correctness_finite_differences(platform, precision):
     )
 
 
+def test_gradient_through_checkpointed_scan():
+    """Reverse mode must work through the Pairformer-style remat/scan composition."""
+    q, k, v, bias, mask, scale = create_test_data(
+        "cpu",
+        batch_size=1,
+        n_nodes=1,
+        n_heads=1,
+        seq_len_qo=4,
+        seq_len_kv=4,
+        d_model=8,
+    )
+
+    def body(carry, _):
+        output, _, _ = cuex.triangle_attention(carry, k, v, bias, mask, scale)
+        return output, None
+
+    def loss(q):
+        output, _ = jax.lax.scan(jax.checkpoint(body), q, None, length=2)
+        return jnp.sum(output)
+
+    dq = jax.grad(loss)(q)
+    assert dq.shape == q.shape
+    assert jnp.all(jnp.isfinite(dq))
+
+
 @pytest.mark.parametrize("platform", ["cpu", "cuda"])
 @pytest.mark.parametrize(
     "batch_size, n_nodes, n_heads, seq_len_qo, seq_len_kv, d_model", SHAPE_CONFIGS


### PR DESCRIPTION
Follow-up to #295.

## Summary

- add a public CPU regression for reverse-mode differentiation through checkpointed triangle attention inside jax.lax.scan
- correct the public return documentation from tuple to three-element list

## Validation

- mutation check: the new test fails with the pre-#295 tuple return and the expected custom-VJP pytree mismatch
- JAX_PLATFORMS=cpu python -m pytest -q cuequivariance_jax/tests: 87 passed, 36 skipped