### PR TITLE
[JAX] Add attention_pair_bias frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## (unreleased)
 
 ### Added
+- [JAX] Added `cuex.attention_pair_bias` with raw and cached pair-projection API parity, a portable pure-JAX implementation, and optional `cuequivariance_ops_jax` triangle-attention FFI acceleration for eligible FP16/BF16 CUDA inputs.
 - [Torch] `cuet.triangle_attention` accepts `kv_lengths`, an int32 per-row key/value length tensor for right-padded sequence masks. Passing `kv_lengths` selects the Blackwell sm100f length fast path when available; dense `mask` remains the correct fallback path for arbitrary masks. Added `cuet.mask_to_kv_lengths` to convert and validate prefix masks.
 - [Torch] `cuet.attention_pair_bias` exposes the optional generalized (Proteina/Complexa) projection parameters `b_proj_k`, `b_proj_v`, `w_ln_q`/`b_ln_q`, `w_ln_k`/`b_ln_k`, and `b_proj_g` as keyword-only arguments forwarded to the backend. They default to `None`, so the strict OpenFold3/Boltz contract applied to `single_repr` is unchanged; supplying them adds the K/V/gate projection biases and the post-projection Q/K LayerNorm (over the full `H * DH` dimension, before the head split). The pair-projection weight `w_proj_z` may be omitted when `is_cached_z_proj=True` because the supplied pair representation is already projected. ([#291](https://github.com/NVIDIA/cuEquivariance/pull/291))
 

--- a/cuequivariance_jax/cuequivariance_jax/__init__.py
+++ b/cuequivariance_jax/cuequivariance_jax/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,6 +49,7 @@ from .triangle import (
     triangle_multiplicative_update,
     Precision as TriMulPrecision,
     triangle_attention,
+    attention_pair_bias,
 )
 from . import flax_linen
 from . import experimental
@@ -76,6 +77,7 @@ __all__ = [
     "triangle_multiplicative_update",
     "TriMulPrecision",
     "triangle_attention",
+    "attention_pair_bias",
     "flax_linen",
     "experimental",
     "nnx",

--- a/cuequivariance_jax/cuequivariance_jax/triangle/__init__.py
+++ b/cuequivariance_jax/cuequivariance_jax/triangle/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,9 +17,11 @@ from ._triangle_multiplicative_update import (
     triangle_multiplicative_update,
 )
 from ._triangle_attention import triangle_attention
+from ._attention_pair_bias import attention_pair_bias
 
 __all__ = [
     "Precision",
     "triangle_multiplicative_update",
     "triangle_attention",
+    "attention_pair_bias",
 ]

--- a/cuequivariance_jax/cuequivariance_jax/triangle/_attention_pair_bias.py
+++ b/cuequivariance_jax/cuequivariance_jax/triangle/_attention_pair_bias.py
@@ -1,0 +1,354 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Attention with pair bias for JAX."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import jax
+import jax.numpy as jnp
+
+try:
+    from cuequivariance_ops_jax import (
+        attention_pair_bias as _attention_pair_bias_backend,
+    )
+
+    HAS_CUE_OPS_JAX_APB = True
+except ImportError:
+    _attention_pair_bias_backend = None
+    HAS_CUE_OPS_JAX_APB = False
+
+
+def _layer_norm(
+    x: jax.Array,
+    weight: Optional[jax.Array],
+    bias: Optional[jax.Array],
+    eps: float,
+) -> jax.Array:
+    output_dtype = x.dtype
+    stats_dtype = (
+        jnp.float32
+        if output_dtype in (jnp.float16, jnp.bfloat16)
+        else output_dtype
+    )
+    x_stats = x.astype(stats_dtype)
+    centered = x_stats - jnp.mean(x_stats, axis=-1, keepdims=True)
+    variance = jnp.mean(jnp.square(centered), axis=-1, keepdims=True)
+    normalized = centered * jax.lax.rsqrt(variance + eps)
+    if weight is not None:
+        normalized = normalized * weight.astype(stats_dtype)
+    if bias is not None:
+        normalized = normalized + bias.astype(stats_dtype)
+    return normalized.astype(output_dtype)
+
+
+def _linear(
+    x: jax.Array,
+    weight: jax.Array,
+    bias: Optional[jax.Array],
+    precision: jax.lax.Precision | None,
+) -> jax.Array:
+    dtype = x.dtype
+    out = jnp.einsum(
+        "...d,od->...o",
+        x,
+        weight.astype(dtype),
+        precision=precision,
+    )
+    if bias is not None:
+        out = out + bias.astype(dtype)
+    return out
+
+
+def _validate_inputs(
+    single_repr: jax.Array,
+    pair_repr: jax.Array,
+    mask: Optional[jax.Array],
+    num_heads: int,
+    w_ln_a: jax.Array,
+    w_proj_q: jax.Array,
+    w_proj_k: jax.Array,
+    w_proj_v: jax.Array,
+    w_proj_g: jax.Array,
+    w_proj_o: jax.Array,
+    w_proj_z: Optional[jax.Array],
+    *,
+    is_cached_z_proj: bool,
+) -> tuple[int, int, int, int, int]:
+    if single_repr.ndim != 3:
+        raise ValueError(
+            f"single_repr must have shape (B * M, N, D), got {single_repr.shape}"
+        )
+    if pair_repr.ndim != 4:
+        raise ValueError(
+            "pair_repr must have shape (B, N, N, D_z), or (B, H, N, N) "
+            f"when cached, got {pair_repr.shape}"
+        )
+    if num_heads <= 0:
+        raise ValueError(f"num_heads must be positive, got {num_heads}")
+
+    BM, N, D = single_repr.shape
+    B = pair_repr.shape[0]
+    if B < 1:
+        raise ValueError("pair_repr batch dimension must be >= 1")
+    if BM % B != 0:
+        raise ValueError(
+            f"single_repr batch {BM} must be divisible by pair_repr batch {B}"
+        )
+    multiplicity = BM // B
+
+    projected_channels = w_proj_q.shape[0]
+    if projected_channels % num_heads != 0:
+        raise ValueError(
+            f"projected channels {projected_channels} must be divisible by "
+            f"num_heads {num_heads}"
+        )
+    head_dim = projected_channels // num_heads
+    for name, value in (
+        ("w_proj_q", w_proj_q),
+        ("w_proj_k", w_proj_k),
+        ("w_proj_v", w_proj_v),
+        ("w_proj_g", w_proj_g),
+    ):
+        if value.shape != (projected_channels, D):
+            raise ValueError(
+                f"{name} must have shape {(projected_channels, D)}, "
+                f"got {value.shape}"
+            )
+    if w_proj_o.shape != (D, projected_channels):
+        raise ValueError(
+            f"w_proj_o must have shape {(D, projected_channels)}, "
+            f"got {w_proj_o.shape}"
+        )
+    if w_ln_a.shape != (D,):
+        raise ValueError(f"w_ln_a must have shape {(D,)}, got {w_ln_a.shape}")
+
+    if is_cached_z_proj:
+        if pair_repr.shape != (B, num_heads, N, N):
+            raise ValueError(
+                "cached pair_repr must have shape "
+                f"{(B, num_heads, N, N)}, got {pair_repr.shape}"
+            )
+    else:
+        if pair_repr.shape[1:3] != (N, N):
+            raise ValueError(
+                f"raw pair_repr must have square sequence axes {(N, N)}, "
+                f"got {pair_repr.shape[1:3]}"
+            )
+        if w_proj_z is None:
+            raise ValueError("w_proj_z is required when is_cached_z_proj is False")
+        if w_proj_z.shape != (num_heads, pair_repr.shape[-1]):
+            raise ValueError(
+                f"w_proj_z must have shape {(num_heads, pair_repr.shape[-1])}, "
+                f"got {w_proj_z.shape}"
+            )
+
+    if mask is not None and mask.shape not in ((B, N), (BM, N)):
+        raise ValueError(
+            f"mask must have shape {(B, N)} or {(BM, N)}, got {mask.shape}"
+        )
+    return B, BM, N, head_dim, multiplicity
+
+
+def _attention_pair_bias_reference(
+    single_repr: jax.Array,
+    pair_repr: jax.Array,
+    mask: Optional[jax.Array],
+    num_heads: int,
+    w_ln_a: jax.Array,
+    b_ln_a: Optional[jax.Array],
+    w_proj_q: jax.Array,
+    b_proj_q: Optional[jax.Array],
+    w_proj_k: jax.Array,
+    w_proj_v: jax.Array,
+    w_proj_g: jax.Array,
+    w_proj_o: jax.Array,
+    w_proj_z: Optional[jax.Array] = None,
+    b_proj_o: Optional[jax.Array] = None,
+    b_proj_z: Optional[jax.Array] = None,
+    w_ln_z: Optional[jax.Array] = None,
+    b_ln_z: Optional[jax.Array] = None,
+    inf: float = 1e6,
+    eps: float = 1e-5,
+    attn_scale: Optional[float] = None,
+    return_z_proj: bool = False,
+    is_cached_z_proj: bool = False,
+    *,
+    b_proj_k: Optional[jax.Array] = None,
+    b_proj_v: Optional[jax.Array] = None,
+    w_ln_q: Optional[jax.Array] = None,
+    b_ln_q: Optional[jax.Array] = None,
+    w_ln_k: Optional[jax.Array] = None,
+    b_ln_k: Optional[jax.Array] = None,
+    b_proj_g: Optional[jax.Array] = None,
+    precision: jax.lax.Precision | None = None,
+) -> tuple[jax.Array, Optional[jax.Array]]:
+    """Pure-JAX reference implementation."""
+    B, BM, N, head_dim, multiplicity = _validate_inputs(
+        single_repr,
+        pair_repr,
+        mask,
+        num_heads,
+        w_ln_a,
+        w_proj_q,
+        w_proj_k,
+        w_proj_v,
+        w_proj_g,
+        w_proj_o,
+        w_proj_z,
+        is_cached_z_proj=is_cached_z_proj,
+    )
+    input_dtype = single_repr.dtype
+    normalized = _layer_norm(single_repr, w_ln_a, b_ln_a, eps)
+    q = _linear(normalized, w_proj_q, b_proj_q, precision)
+    k = _linear(normalized, w_proj_k, b_proj_k, precision)
+    v = _linear(normalized, w_proj_v, b_proj_v, precision)
+    if w_ln_q is not None or b_ln_q is not None:
+        q = _layer_norm(q, w_ln_q, b_ln_q, eps)
+    if w_ln_k is not None or b_ln_k is not None:
+        k = _layer_norm(k, w_ln_k, b_ln_k, eps)
+    q, k, v = (
+        value.reshape(BM, N, num_heads, head_dim).transpose(0, 2, 1, 3)
+        for value in (q, k, v)
+    )
+
+    if is_cached_z_proj:
+        z_proj = pair_repr
+    else:
+        z_norm = _layer_norm(pair_repr, w_ln_z, b_ln_z, eps)
+        z_proj = _linear(z_norm, w_proj_z, b_proj_z, precision)
+        z_proj = jnp.transpose(z_proj, (0, 3, 1, 2))
+    z_proj = z_proj.astype(input_dtype)
+    z_expanded = jnp.repeat(z_proj, multiplicity, axis=0)
+
+    if mask is None:
+        expanded_mask = jnp.ones((BM, N), dtype=jnp.float32)
+    else:
+        expanded_mask = mask.astype(jnp.float32)
+        if mask.shape[0] == B:
+            expanded_mask = jnp.repeat(expanded_mask, multiplicity, axis=0)
+    pair_bias = (
+        z_expanded.astype(jnp.float32)
+        + (1.0 - expanded_mask[:, None, None, :]) * (-inf)
+    ).astype(input_dtype)
+
+    scale = head_dim**-0.5 if attn_scale is None else attn_scale
+    scores = jnp.einsum(
+        "bhid,bhjd->bhij", q, k, precision=precision
+    ).astype(jnp.float32)
+    scores = scores * scale + pair_bias.astype(jnp.float32)
+    attention = jax.nn.softmax(scores, axis=-1).astype(input_dtype)
+    out = jnp.einsum(
+        "bhij,bhjd->bihd", attention, v, precision=precision
+    ).reshape(BM, N, num_heads * head_dim)
+
+    gate = jax.nn.sigmoid(
+        _linear(normalized, w_proj_g, b_proj_g, precision)
+    )
+    output = _linear(gate * out, w_proj_o, b_proj_o, precision).astype(
+        input_dtype
+    )
+    return output, z_proj if return_z_proj else None
+
+
+def attention_pair_bias(
+    single_repr: jax.Array,
+    pair_repr: jax.Array,
+    mask: Optional[jax.Array],
+    num_heads: int,
+    w_ln_a: jax.Array,
+    b_ln_a: Optional[jax.Array],
+    w_proj_q: jax.Array,
+    b_proj_q: Optional[jax.Array],
+    w_proj_k: jax.Array,
+    w_proj_v: jax.Array,
+    w_proj_g: jax.Array,
+    w_proj_o: jax.Array,
+    w_proj_z: Optional[jax.Array] = None,
+    b_proj_o: Optional[jax.Array] = None,
+    b_proj_z: Optional[jax.Array] = None,
+    w_ln_z: Optional[jax.Array] = None,
+    b_ln_z: Optional[jax.Array] = None,
+    inf: float = 1e6,
+    eps: float = 1e-5,
+    attn_scale: Optional[float] = None,
+    return_z_proj: bool = False,
+    is_cached_z_proj: bool = False,
+    *,
+    b_proj_k: Optional[jax.Array] = None,
+    b_proj_v: Optional[jax.Array] = None,
+    w_ln_q: Optional[jax.Array] = None,
+    b_ln_q: Optional[jax.Array] = None,
+    w_ln_k: Optional[jax.Array] = None,
+    b_ln_k: Optional[jax.Array] = None,
+    b_proj_g: Optional[jax.Array] = None,
+    precision: jax.lax.Precision | None = None,
+) -> tuple[jax.Array, Optional[jax.Array]]:
+    """Compute attention with a pairwise bias.
+
+    This matches the Torch APB signature and supports raw pair representations
+    ``[B, N, N, D_z]`` as well as cached projections ``[B, H, N, N]``.  The
+    operation remains available as pure JAX when ``cuequivariance_ops_jax`` is
+    not installed.  When it is installed, eligible CUDA cells reuse its
+    triangle-attention backend while unsupported shapes retain reference
+    semantics. The public APB contract requires at least one valid key in each
+    mask row; fully masked rows are unsupported.
+
+    ``single_repr`` has shape ``[B * M, N, D]``.  ``mask`` may have shape
+    ``[B, N]`` or ``[B * M, N]`` and is an additive finite mask, so gradients
+    with respect to floating masks are preserved.
+    """
+    implementation = (
+        _attention_pair_bias_backend
+        if HAS_CUE_OPS_JAX_APB
+        else _attention_pair_bias_reference
+    )
+    return implementation(
+        single_repr,
+        pair_repr,
+        mask,
+        num_heads,
+        w_ln_a,
+        b_ln_a,
+        w_proj_q,
+        b_proj_q,
+        w_proj_k,
+        w_proj_v,
+        w_proj_g,
+        w_proj_o,
+        w_proj_z,
+        b_proj_o,
+        b_proj_z,
+        w_ln_z,
+        b_ln_z,
+        inf,
+        eps,
+        attn_scale,
+        return_z_proj,
+        is_cached_z_proj,
+        b_proj_k=b_proj_k,
+        b_proj_v=b_proj_v,
+        w_ln_q=w_ln_q,
+        b_ln_q=b_ln_q,
+        w_ln_k=w_ln_k,
+        b_ln_k=b_ln_k,
+        b_proj_g=b_proj_g,
+        precision=precision,
+    )
+
+
+__all__ = ["attention_pair_bias"]

--- a/cuequivariance_jax/cuequivariance_jax/triangle/_attention_pair_bias.py
+++ b/cuequivariance_jax/cuequivariance_jax/triangle/_attention_pair_bias.py
@@ -41,9 +41,7 @@ def _layer_norm(
 ) -> jax.Array:
     output_dtype = x.dtype
     stats_dtype = (
-        jnp.float32
-        if output_dtype in (jnp.float16, jnp.bfloat16)
-        else output_dtype
+        jnp.float32 if output_dtype in (jnp.float16, jnp.bfloat16) else output_dtype
     )
     x_stats = x.astype(stats_dtype)
     centered = x_stats - jnp.mean(x_stats, axis=-1, keepdims=True)
@@ -126,13 +124,11 @@ def _validate_inputs(
     ):
         if value.shape != (projected_channels, D):
             raise ValueError(
-                f"{name} must have shape {(projected_channels, D)}, "
-                f"got {value.shape}"
+                f"{name} must have shape {(projected_channels, D)}, got {value.shape}"
             )
     if w_proj_o.shape != (D, projected_channels):
         raise ValueError(
-            f"w_proj_o must have shape {(D, projected_channels)}, "
-            f"got {w_proj_o.shape}"
+            f"w_proj_o must have shape {(D, projected_channels)}, got {w_proj_o.shape}"
         )
     if w_ln_a.shape != (D,):
         raise ValueError(f"w_ln_a must have shape {(D,)}, got {w_ln_a.shape}")
@@ -247,21 +243,17 @@ def _attention_pair_bias_reference(
     ).astype(input_dtype)
 
     scale = head_dim**-0.5 if attn_scale is None else attn_scale
-    scores = jnp.einsum(
-        "bhid,bhjd->bhij", q, k, precision=precision
-    ).astype(jnp.float32)
+    scores = jnp.einsum("bhid,bhjd->bhij", q, k, precision=precision).astype(
+        jnp.float32
+    )
     scores = scores * scale + pair_bias.astype(jnp.float32)
     attention = jax.nn.softmax(scores, axis=-1).astype(input_dtype)
-    out = jnp.einsum(
-        "bhij,bhjd->bihd", attention, v, precision=precision
-    ).reshape(BM, N, num_heads * head_dim)
+    out = jnp.einsum("bhij,bhjd->bihd", attention, v, precision=precision).reshape(
+        BM, N, num_heads * head_dim
+    )
 
-    gate = jax.nn.sigmoid(
-        _linear(normalized, w_proj_g, b_proj_g, precision)
-    )
-    output = _linear(gate * out, w_proj_o, b_proj_o, precision).astype(
-        input_dtype
-    )
+    gate = jax.nn.sigmoid(_linear(normalized, w_proj_g, b_proj_g, precision))
+    output = _linear(gate * out, w_proj_o, b_proj_o, precision).astype(input_dtype)
     return output, z_proj if return_z_proj else None
 
 

--- a/cuequivariance_jax/tests/attention_pair_bias_test.py
+++ b/cuequivariance_jax/tests/attention_pair_bias_test.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import cuequivariance_jax as cuex
+
+
+def _inputs(dtype=jnp.float32):
+    B, M, N, D, H, DH, DZ = 2, 2, 3, 4, 2, 3, 5
+    keys = jax.random.split(jax.random.key(123), 18)
+
+    def normal(index, shape):
+        return jax.random.normal(keys[index], shape, dtype=dtype)
+
+    return {
+        "single_repr": normal(0, (B * M, N, D)),
+        "pair_repr": normal(1, (B, N, N, DZ)),
+        "mask": jnp.asarray(
+            [[1.0, 1.0, 0.25], [1.0, 0.5, 1.0]], dtype=dtype
+        ),
+        "num_heads": H,
+        "w_ln_a": normal(2, (D,)),
+        "b_ln_a": normal(3, (D,)),
+        "w_proj_q": normal(4, (H * DH, D)),
+        "b_proj_q": normal(5, (H * DH,)),
+        "w_proj_k": normal(6, (H * DH, D)),
+        "w_proj_v": normal(7, (H * DH, D)),
+        "w_proj_g": normal(8, (H * DH, D)),
+        "w_proj_o": normal(9, (D, H * DH)),
+        "w_proj_z": normal(10, (H, DZ)),
+        "b_proj_o": normal(11, (D,)),
+        "b_proj_z": normal(12, (H,)),
+        "w_ln_z": normal(13, (DZ,)),
+        "b_ln_z": normal(14, (DZ,)),
+        "b_proj_k": normal(15, (H * DH,)),
+        "b_proj_v": normal(16, (H * DH,)),
+        "b_proj_g": normal(17, (H * DH,)),
+        "w_ln_q": jnp.linspace(0.5, 1.5, H * DH, dtype=dtype),
+        "b_ln_q": jnp.linspace(-0.2, 0.2, H * DH, dtype=dtype),
+        "w_ln_k": jnp.linspace(0.75, 1.25, H * DH, dtype=dtype),
+        "b_ln_k": jnp.linspace(0.1, -0.1, H * DH, dtype=dtype),
+    }
+
+
+def _call(values, **kwargs):
+    arguments = dict(values)
+    arguments.update(kwargs)
+    return cuex.attention_pair_bias(**arguments)
+
+
+def test_attention_pair_bias_raw_and_cached_projection_match():
+    values = _inputs()
+    output, z_proj = _call(values, return_z_proj=True)
+
+    cached = dict(values)
+    cached["pair_repr"] = z_proj
+    cached["w_proj_z"] = None
+    output_cached, returned = _call(cached, is_cached_z_proj=True)
+
+    assert output.shape == values["single_repr"].shape
+    assert z_proj.shape == (2, 2, 3, 3)
+    assert returned is None
+    np.testing.assert_allclose(output_cached, output, rtol=2e-5, atol=2e-5)
+
+
+def test_attention_pair_bias_jit_vjp_and_floating_mask_gradient():
+    values = _inputs()
+
+    def loss(single_repr, pair_repr, mask):
+        local = dict(values)
+        local.update(
+            single_repr=single_repr,
+            pair_repr=pair_repr,
+            mask=mask,
+        )
+        output, z_proj = _call(local, return_z_proj=True)
+        return jnp.sum(output.astype(jnp.float32) ** 2) + 0.01 * jnp.sum(z_proj)
+
+    compiled = jax.jit(jax.value_and_grad(loss, argnums=(0, 1, 2)))
+    value, gradients = compiled(
+        values["single_repr"], values["pair_repr"], values["mask"]
+    )
+
+    assert jnp.isfinite(value)
+    for gradient, expected in zip(
+        gradients,
+        (values["single_repr"], values["pair_repr"], values["mask"]),
+        strict=True,
+    ):
+        assert gradient.shape == expected.shape
+        assert jnp.all(jnp.isfinite(gradient))
+    assert jnp.any(gradients[2] != 0)
+
+
+def test_attention_pair_bias_nested_vmap_reference_path():
+    values = _inputs()
+    single = jnp.stack([values["single_repr"], values["single_repr"] + 0.1])
+    pair = jnp.stack([values["pair_repr"], values["pair_repr"] - 0.1])
+    mask = jnp.stack([values["mask"], values["mask"]])
+    single = jnp.stack([single, single + 0.2])
+    pair = jnp.stack([pair, pair + 0.2])
+    mask = jnp.stack([mask, mask])
+
+    def operation(single_repr, pair_repr, pair_mask):
+        local = dict(values)
+        local.update(
+            single_repr=single_repr,
+            pair_repr=pair_repr,
+            mask=pair_mask,
+        )
+        return _call(local)[0]
+
+    output = jax.jit(jax.vmap(jax.vmap(operation)))(single, pair, mask)
+    assert output.shape == (2, 2) + values["single_repr"].shape
+    assert jnp.all(jnp.isfinite(output))

--- a/cuequivariance_jax/tests/attention_pair_bias_test.py
+++ b/cuequivariance_jax/tests/attention_pair_bias_test.py
@@ -30,9 +30,7 @@ def _inputs(dtype=jnp.float32):
     return {
         "single_repr": normal(0, (B * M, N, D)),
         "pair_repr": normal(1, (B, N, N, DZ)),
-        "mask": jnp.asarray(
-            [[1.0, 1.0, 0.25], [1.0, 0.5, 1.0]], dtype=dtype
-        ),
+        "mask": jnp.asarray([[1.0, 1.0, 0.25], [1.0, 0.5, 1.0]], dtype=dtype),
         "num_heads": H,
         "w_ln_a": normal(2, (D,)),
         "b_ln_a": normal(3, (D,)),

--- a/docs/api/cuequivariance_jax.rst
+++ b/docs/api/cuequivariance_jax.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
    SPDX-License-Identifier: Apache-2.0
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -112,6 +112,7 @@ Triangle
 
    triangle_multiplicative_update
    triangle_attention
+   attention_pair_bias
 
 Experimental
 ------------

--- a/docs/tutorials/jax/attention_pair_bias.rst
+++ b/docs/tutorials/jax/attention_pair_bias.rst
@@ -1,0 +1,72 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+   SPDX-License-Identifier: Apache-2.0
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+Attention pair bias
+===================
+
+``cuequivariance_jax.attention_pair_bias`` is the JAX frontend for APB. The
+frontend owns the public API, argument validation, and portable pure-JAX
+implementation. When ``cuequivariance_ops_jax`` is installed, the same call is
+delegated to its backend, which owns CUDA FFI eligibility and differentiation.
+Keeping those responsibilities separate means installing the CUDA package is
+an optimization, rather than a requirement for API availability.
+
+Raw and cached pair representations
+-----------------------------------
+
+The API matches the APB interface used by the other cuEquivariance frontends.
+It accepts raw pair features with shape ``(B, N, N, D_z)``. With
+``return_z_proj=True``, the second return value has shape ``(B, H, N, N)`` and
+can be passed back as ``pair_repr`` with ``is_cached_z_proj=True``. The raw and
+cached forms produce the same attention result up to the selected numeric
+precision. ``single_repr`` may have batch ``B * M``; pair features and a
+``(B, N)`` mask are repeated over that multiplicity.
+
+Portability and numeric behavior
+--------------------------------
+
+The pure-JAX implementation handles CPU and GPU execution, JIT, VJP, and
+nested ``vmap``. It is also the fallback when the CUDA backend is unavailable
+or an attention cell is not eligible for FFI. Eligible CUDA cells use FP16 or
+BF16, a head dimension divisible by eight and no larger than 128, and a
+sequence length divisible by eight. FP32 and unsupported shapes use pure JAX.
+
+The public APB contract requires at least one valid key in every mask row. The
+optimized backend relies on that precondition and does not add a
+data-dependent reduction or conditional for fully masked rows. Fully masked
+rows are unsupported in both the frontend and backend.
+
+For FP16 and BF16 inputs, layer-normalization statistics are accumulated in
+FP32 and outputs retain the input dtype. ``precision`` controls JAX contraction
+precision. Masking is a finite additive penalty (``inf=1e6`` by default), not a
+Boolean-only transformation, so floating masks retain gradients.
+
+Validated hardware
+------------------
+
+The current backend validation matrix is:
+
+==================  ==================  ==========================  ================================
+GPU                 Compute capability  Eligible BF16 FFI backend  Status
+==================  ==================  ==========================  ================================
+RTX A6000           8.6                 generic                     Forward/backward parity verified
+A100 80 GB PCIe     8.0                 generic                     Forward/backward parity verified
+H100 80 GB HBM3     9.0                 generic                     Forward/backward parity verified
+B200                10.0                SM100f                      Forward/backward parity verified
+B300                10.3                SM100f                      Forward/backward parity verified
+==================  ==================  ==========================  ================================
+
+The matrix is target validation, not a claim that launch tuning transfers
+unchanged between architectures.

--- a/docs/tutorials/jax/index.rst
+++ b/docs/tutorials/jax/index.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
    SPDX-License-Identifier: Apache-2.0
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,4 +21,4 @@ JAX Examples
 
    poly
    ir_dict
-
+   attention_pair_bias


### PR DESCRIPTION
Adds a public `cuequivariance_jax.attention_pair_bias` frontend for attention pair bias, mirroring the `cuet.attention_pair_bias` API.

**What it does**
- Public API with raw pair input `(B, N, N, D_z)` and cached pair-projection mode (`return_z_proj=True` -> pass back with `is_cached_z_proj=True`), multiplicity over `single_repr`, optional generalized Q/K projection parameters, and keyword-only `precision`.
- Portable pure-JAX implementation: CPU and GPU, `jax.jit`, VJP, and nested `vmap`; this is also the fallback path.
- When the optional `cuequivariance_ops_jax` package is installed, eligible CUDA cells (FP16/BF16, head dim divisible by 8 and <= 128, sequence length divisible by 8) are delegated to its triangle-attention FFI backend. Installing the CUDA package is an optimization, not an API requirement.
- Masking is a finite additive penalty (default `inf=1e6`) so floating masks stay differentiable; fully masked rows remain unsupported per the APB contract.

**Tests**
- New `attention_pair_bias_test.py`: parity of raw vs cached forms, gradient checks, JIT/vmap.
- Full `cuequivariance_jax` test suite passes locally against current `main` (83 passed; GPU-only skipped).

**Related**
- Backend (`cuequivariance_ops_jax`) FFI acceleration is staged separately in kernelcatcher MR !634.

CC @NVIDIA/cuEquivariance-maintainers
